### PR TITLE
Adds support for a malpedia.json config

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -1,0 +1,5 @@
+{
+    "apitoken": null,
+    "username": null,
+    "password": null
+}


### PR DESCRIPTION
## Description

Adds support for a `malpedia.json` config file. This file is searched for
in the following common locations.

- the current working directory + "malpedia.json"
- the current working directory + ".malpedia.json"
- "$HOME/.malpedia.json"
- "/etc/malpedia.json"
- "%APPDATA%\malpedia\malpedia.json" (for windows)

The first file that was found is used. Should a file be found but a
parse error occurs, a corresponding error message is emitted and the
software continues as if no config is present. Consequently no further
locations are searched if a file was found but does not contain valid
json.

If no such file was found, the software attempts to load a config.py as
previously. This is kept for backwards compatibility.

Example config file:

```json
{
    "username": null,
    "password": null,
    "apitoken": "<justanexample>"
}
```

Apitoken authentication is prefered over username password
authentication.

## Why json?

There's a couple of reasons against using python for configs:
- It's awkward for end-users that don't necessarily know a lot about python
- Config files are commonly located in the users home directory and I am
  not sure how well imports on absolute paths work.
- `import`-ing a config file just feels wrong as there might be any code in
  there that might be run unintentionally (security issue). As of this commit
  the import is still done if no other config exists, but I'd argue in favour of the
  removal of that import.

Personally I would have preferred yaml over json but the json package
was already imported and I did not want to add another dependency.
If you prefer yaml as well it would be quite easy for me to swap the
json for yaml at the cost of another dependency.

## Finally

I hope this feature helps. Let me know if you want any changes.